### PR TITLE
Implement AddOp and SubOp

### DIFF
--- a/include/sysy/SysyOps.td
+++ b/include/sysy/SysyOps.td
@@ -16,4 +16,24 @@ def Sysy_MatmulOp : Op<Sysy_Dialect, "matmul"> {
   let assemblyFormat = "$dst `,` $lhs `,` $rhs attr-dict `:` type($dst) `,` type($lhs) `,` type($rhs)";
 }
 
+def Sysy_AddOp : Op<Sysy_Dialect, "add"> {
+  let summary = "sysy tensor addition";
+  let description = [{
+      Addtion for sysy tensor in various dimensions.
+  }];
+
+  let arguments = (ins MemType:$dst, MemType:$lhs, MemType:$rhs);
+  let assemblyFormat = "$dst `,` $lhs `,` $rhs attr-dict `:` type($dst) `,` type($lhs) `,` type($rhs)";
+}
+
+def Sysy_SubOp : Op<Sysy_Dialect, "sub"> {
+  let summary = "sysy tensor substraction";
+  let description = [{
+      Substraction for sysy tensor in various dimensions.
+  }];
+
+  let arguments = (ins MemType:$dst, MemType:$lhs, MemType:$rhs);
+  let assemblyFormat = "$dst `,` $lhs `,` $rhs attr-dict `:` type($dst) `,` type($lhs) `,` type($rhs)";
+}
+
 #endif // SYSY_SYSYOPS_TD_

--- a/tests/add.mlir
+++ b/tests/add.mlir
@@ -1,0 +1,25 @@
+func.func @test_add_f32_2d(%C: memref<2048x2048xf32>, %A: memref<2048x2048xf32>, %B: memref<2048x2048xf32>) {
+  sysy.add %C, %A, %B : memref<2048x2048xf32>, memref<2048x2048xf32>, memref<2048x2048xf32>
+  func.return
+}
+
+//-----------------
+
+func.func @test_add_f32_1d(%C: memref<2048xf32>, %A: memref<2048xf32>, %B: memref<2048xf32>) {
+  sysy.add %C, %A, %B : memref<2048xf32>, memref<2048xf32>, memref<2048xf32>
+  func.return
+}
+
+//-----------------
+
+func.func @test_add_f32_3d(%C: memref<2048x2048x2048xf32>, %A: memref<2048x2048x2048xf32>, %B: memref<2048x2048x2048xf32>) {
+  sysy.add %C, %A, %B : memref<2048x2048x2048xf32>, memref<2048x2048x2048xf32>, memref<2048x2048x2048xf32>
+  func.return
+}
+
+//-----------------
+
+func.func @test_add_int_2d(%C: memref<2048x2048xi32>, %A: memref<2048x2048xi32>, %B: memref<2048x2048xi32>) {
+  sysy.add %C, %A, %B : memref<2048x2048xi32>, memref<2048x2048xi32>, memref<2048x2048xi32>
+  func.return
+}

--- a/tests/sub.mlir
+++ b/tests/sub.mlir
@@ -1,0 +1,25 @@
+func.func @test_sub_f32_2d(%C: memref<2048x2048xf32>, %A: memref<2048x2048xf32>, %B: memref<2048x2048xf32>) {
+  sysy.sub %C, %A, %B : memref<2048x2048xf32>, memref<2048x2048xf32>, memref<2048x2048xf32>
+  func.return
+}
+
+//-----------------
+
+func.func @test_sub_f32_1d(%C: memref<2048xf32>, %A: memref<2048xf32>, %B: memref<2048xf32>) {
+  sysy.sub %C, %A, %B : memref<2048xf32>, memref<2048xf32>, memref<2048xf32>
+  func.return
+}
+
+//-----------------
+
+func.func @test_sub_f32_3d(%C: memref<2048x2048x2048xf32>, %A: memref<2048x2048x2048xf32>, %B: memref<2048x2048x2048xf32>) {
+  sysy.sub %C, %A, %B : memref<2048x2048x2048xf32>, memref<2048x2048x2048xf32>, memref<2048x2048x2048xf32>
+  func.return
+}
+
+//-----------------
+
+func.func @test_sub_int_2d(%C: memref<2048x2048xi32>, %A: memref<2048x2048xi32>, %B: memref<2048x2048xi32>) {
+  sysy.sub %C, %A, %B : memref<2048x2048xi32>, memref<2048x2048xi32>, memref<2048x2048xi32>
+  func.return
+}


### PR DESCRIPTION
Implement the definition of `sysy.add` and `sysy.sub` for 1D to 3D tensor along with their Lowering implementation.